### PR TITLE
Pin Sprockets to v3, fix Github Actions

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,6 +1,6 @@
 name: RSpec
 
-on: [ push, pull_request ]
+on: push
 
 jobs:
   tests:
@@ -11,31 +11,22 @@ jobs:
         # Maintained versions: 2.7, 3.0, 3.1
         # Security updates only: 2.6 (EOL: 2022-03-31)
         # Source: https://www.ruby-lang.org/en/downloads/branches/
-        ruby: [ 2.6, 2.7 ]
+        ruby:
+          - "2.6"
+          - "2.7"
         gemfile:
           - rails-5.2.x
           - rails-6.1.x
-        # Add extra vars for each gem
-        include:
-          - gem: core
-            bundle-without: attachments:pages
-          - gem: attachments
-            bundle-without: pages
-          - gem: pages
-            bundle-without:
     env:
-      BUNDLE_WITHOUT: ${{ matrix.bundle-without }}
-      BUNDLE_GEMFILE: "${{ GITHUB_WORKSPACE }}/gemfiles/${{ matrix.gemfile }}.gemfile"
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
       RAILS_ENV: test
+    name: "Ruby ${{ matrix.ruby }}, ${{ matrix.gemfile }}"
     steps:
       - uses: actions/checkout@v2
-      - run: cd ${{ matrix.gem }}
       - name: Set up Ruby & bundle gems
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - name: Prepare DB
-        run: bundle exec rake db:schema:load
       - name: Run the tests
-        run: bundle exec rspec
+        run: bundle exec rake spec

--- a/gemfiles/rails-5.2.x.gemfile
+++ b/gemfiles/rails-5.2.x.gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.2.0"
+gem "sprockets", "< 4.0" # Sprockets 4 is too new for Rails 5
 
 gemspec name: "brightcontent-core", path: "../core", group: :core
 gemspec name: "brightcontent-attachments", path: "../attachments", group: :attachments

--- a/gemfiles/rails-6.1.x.gemfile
+++ b/gemfiles/rails-6.1.x.gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 6.1.0"
+gem "sprockets", "< 4.0"
 
 gemspec name: "brightcontent-core", path: "../core", group: :core
 gemspec name: "brightcontent-attachments", path: "../attachments", group: :attachments


### PR DESCRIPTION
Sprockets 4 requires a migration from v3, which the codebase has not yet gone through. For now I'm restricting Sprockets to be at most v3 to preserve compatibility.

- [Migration guide](https://github.com/rails/sprockets/blob/master/UPGRADING.md)
- [Sprockets v4 changelog](https://github.com/rails/sprockets/blob/master/CHANGELOG.md)

This stabilizes my local tests (when setting Ruby version to a supported version).

Github Actions finally reported why it was not working: because the configuration from #1 had issues. I've addressed this issue here to get CI test results for all ruby/rails permutations we want to support (Ruby 2.6 and 2.7 vs Rails 5.2 and 6.1)